### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/204/495/421204495.geojson
+++ b/data/421/204/495/421204495.geojson
@@ -601,6 +601,9 @@
     },
     "wof:country":"CM",
     "wof:created":1459010188,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b30837628297cec3ff971736517f10ef",
     "wof:hierarchy":[
         {
@@ -612,7 +615,7 @@
         }
     ],
     "wof:id":421204495,
-    "wof:lastmodified":1566646024,
+    "wof:lastmodified":1582341006,
     "wof:name":"Yaounde",
     "wof:parent_id":85669945,
     "wof:placetype":"locality",

--- a/data/856/322/45/85632245.geojson
+++ b/data/856/322/45/85632245.geojson
@@ -1011,6 +1011,12 @@
     },
     "wof:country":"CM",
     "wof:country_alpha3":"CMR",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth",
+        "quattroshapes",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"01b8e9f22b65b308c8875b3b40087f19",
     "wof:hierarchy":[
         {
@@ -1027,7 +1033,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566645149,
+    "wof:lastmodified":1582340991,
     "wof:name":"Cameroon",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/699/33/85669933.geojson
+++ b/data/856/699/33/85669933.geojson
@@ -302,6 +302,9 @@
         "wk:page":"Far North Region (Cameroon)"
     },
     "wof:country":"CM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8e4891f45549f46920f71cbf0318c81c",
     "wof:hierarchy":[
         {
@@ -319,7 +322,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566645151,
+    "wof:lastmodified":1582340993,
     "wof:name":"Extreme Nord",
     "wof:parent_id":85632245,
     "wof:placetype":"region",

--- a/data/856/699/37/85669937.geojson
+++ b/data/856/699/37/85669937.geojson
@@ -292,6 +292,9 @@
         "wk:page":"Littoral Region (Cameroon)"
     },
     "wof:country":"CM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6f270493151be8e0e13098f7f03b0248",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566645153,
+    "wof:lastmodified":1582340994,
     "wof:name":"Littoral",
     "wof:parent_id":85632245,
     "wof:placetype":"region",

--- a/data/856/699/41/85669941.geojson
+++ b/data/856/699/41/85669941.geojson
@@ -292,6 +292,9 @@
         "wk:page":"Northwest Region (Cameroon)"
     },
     "wof:country":"CM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"10b616db7308aa732c4c9ffb668797e1",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566645153,
+    "wof:lastmodified":1582340994,
     "wof:name":"Nord Ouest",
     "wof:parent_id":85632245,
     "wof:placetype":"region",

--- a/data/856/699/45/85669945.geojson
+++ b/data/856/699/45/85669945.geojson
@@ -297,6 +297,9 @@
         "wk:page":"Centre Region (Cameroon)"
     },
     "wof:country":"CM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a7d97f8560743ebadbd437b98a254c68",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566645152,
+    "wof:lastmodified":1582340993,
     "wof:name":"Centre",
     "wof:parent_id":85632245,
     "wof:placetype":"region",

--- a/data/856/699/49/85669949.geojson
+++ b/data/856/699/49/85669949.geojson
@@ -298,6 +298,9 @@
         "wk:page":"East Region (Cameroon)"
     },
     "wof:country":"CM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"46eee79251657c9b11e7903b32fcc772",
     "wof:hierarchy":[
         {
@@ -315,7 +318,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566645154,
+    "wof:lastmodified":1582340994,
     "wof:name":"Est",
     "wof:parent_id":85632245,
     "wof:placetype":"region",

--- a/data/856/699/53/85669953.geojson
+++ b/data/856/699/53/85669953.geojson
@@ -301,6 +301,9 @@
         "wk:page":"Adamawa Region"
     },
     "wof:country":"CM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d804ab33424f41ea1d03d5bd28086800",
     "wof:hierarchy":[
         {
@@ -318,7 +321,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566645153,
+    "wof:lastmodified":1582340993,
     "wof:name":"Adamaoua",
     "wof:parent_id":85632245,
     "wof:placetype":"region",

--- a/data/856/699/57/85669957.geojson
+++ b/data/856/699/57/85669957.geojson
@@ -296,6 +296,9 @@
         "wk:page":"North Region (Cameroon)"
     },
     "wof:country":"CM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9f7eef009cd82bd34aa5d239acd8bca9",
     "wof:hierarchy":[
         {
@@ -313,7 +316,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566645151,
+    "wof:lastmodified":1582340992,
     "wof:name":"Nord",
     "wof:parent_id":85632245,
     "wof:placetype":"region",

--- a/data/856/699/61/85669961.geojson
+++ b/data/856/699/61/85669961.geojson
@@ -297,6 +297,9 @@
         "wk:page":"West Region (Cameroon)"
     },
     "wof:country":"CM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cf4c5e104b8b23fb831f0aaea5125f70",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566645150,
+    "wof:lastmodified":1582340992,
     "wof:name":"Ouest",
     "wof:parent_id":85632245,
     "wof:placetype":"region",

--- a/data/856/699/67/85669967.geojson
+++ b/data/856/699/67/85669967.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Southwest Region (Cameroon)"
     },
     "wof:country":"CM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"879ede80a1788c88ef4a0caeedbd536f",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566645151,
+    "wof:lastmodified":1582340993,
     "wof:name":"Sud Ouest",
     "wof:parent_id":85632245,
     "wof:placetype":"region",

--- a/data/856/699/71/85669971.geojson
+++ b/data/856/699/71/85669971.geojson
@@ -291,6 +291,9 @@
         "wk:page":"South Region (Cameroon)"
     },
     "wof:country":"CM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"94787c4025f9566e7ed056875b68dc53",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566645154,
+    "wof:lastmodified":1582340994,
     "wof:name":"Sud",
     "wof:parent_id":85632245,
     "wof:placetype":"region",

--- a/data/857/718/41/85771841.geojson
+++ b/data/857/718/41/85771841.geojson
@@ -81,6 +81,9 @@
         "qs:id":222659
     },
     "wof:country":"CM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0487ec68a88a0c59e556cfe80c299067",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1534379257,
+    "wof:lastmodified":1582340991,
     "wof:name":"Akwa",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/718/47/85771847.geojson
+++ b/data/857/718/47/85771847.geojson
@@ -74,6 +74,9 @@
         "qs:id":1325096
     },
     "wof:country":"CM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a579436b9462f707d465d459ad3f40de",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1534379257,
+    "wof:lastmodified":1582340991,
     "wof:name":"Bell",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/718/51/85771851.geojson
+++ b/data/857/718/51/85771851.geojson
@@ -68,6 +68,9 @@
         "qs_pg:id":558970
     },
     "wof:country":"CM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7b3157754c2932644a561759c5640ef8",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566645148,
+    "wof:lastmodified":1582340991,
     "wof:name":"New Deido",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.