### PR TITLE
cm concordances, placetype local, and more

### DIFF
--- a/data/109/201/049/3/1092010493.geojson
+++ b/data/109/201/049/3/1092010493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.124068,
-    "geom:area_square_m":1528112939.200226,
+    "geom:area_square_m":1528112939.200221,
     "geom:bbox":"10.3503063087,4.8807228041,10.8866982923,5.27385760753",
     "geom:latitude":5.072841,
     "geom:longitude":10.588167,
@@ -95,9 +95,10 @@
         "hasc:id":"CM.OU.ND",
         "wd:id":"Q2445638"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896965,
-    "wof:geomhash":"926bd92498d7d0ed905601a959bd7275",
+    "wof:geomhash":"b474fd38e56e13fbc513d4a50c09f66b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1092010493,
-    "wof:lastmodified":1566645946,
+    "wof:lastmodified":1695886382,
     "wof:name":"Nde",
     "wof:parent_id":85669961,
     "wof:placetype":"county",

--- a/data/109/201/052/1/1092010521.geojson
+++ b/data/109/201/052/1/1092010521.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.623372,
-    "geom:area_square_m":7670679481.303064,
+    "geom:area_square_m":7670679594.038943,
     "geom:bbox":"10.458794,4.924299,11.316864,6.263974",
     "geom:latitude":5.64158,
     "geom:longitude":10.918515,
@@ -107,9 +107,10 @@
         "hasc:id":"CM.OU.NO",
         "wd:id":"Q2445359"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896966,
-    "wof:geomhash":"580488b460e1bedd2c16abbb609427f6",
+    "wof:geomhash":"143caa9c3b384ab9c7982f923361d6ce",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092010521,
-    "wof:lastmodified":1690867073,
+    "wof:lastmodified":1695886383,
     "wof:name":"Noun",
     "wof:parent_id":85669961,
     "wof:placetype":"county",

--- a/data/109/201/055/9/1092010559.geojson
+++ b/data/109/201/055/9/1092010559.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.096977,
-    "geom:area_square_m":1193260337.871346,
+    "geom:area_square_m":1193260207.072861,
     "geom:bbox":"10.07936,5.501961,10.567333,5.83396",
     "geom:latitude":5.672837,
     "geom:longitude":10.314953,
@@ -101,9 +101,10 @@
         "hasc:id":"CM.OU.BA",
         "wd:id":"Q2442690"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896968,
-    "wof:geomhash":"72193dd708996540fc763ceafd4b019d",
+    "wof:geomhash":"5b087c16192b1c386fbff7c9cfb38671",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092010559,
-    "wof:lastmodified":1690867073,
+    "wof:lastmodified":1695886383,
     "wof:name":"Bamboutos",
     "wof:parent_id":85669961,
     "wof:placetype":"county",

--- a/data/109/201/059/1/1092010591.geojson
+++ b/data/109/201/059/1/1092010591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032863,
-    "geom:area_square_m":404477044.591454,
+    "geom:area_square_m":404476935.460817,
     "geom:bbox":"10.324083,5.426803,10.582458,5.605728",
     "geom:latitude":5.515416,
     "geom:longitude":10.448055,
@@ -101,9 +101,10 @@
         "hasc:id":"CM.OU.MF",
         "wd:id":"Q2445728"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896969,
-    "wof:geomhash":"5bfb32b7afe49537489824967e2097a3",
+    "wof:geomhash":"fcdbc36e09e3b9427fe63bb6a3c3fb7d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092010591,
-    "wof:lastmodified":1690867081,
+    "wof:lastmodified":1695886389,
     "wof:name":"Mifi",
     "wof:parent_id":85669961,
     "wof:placetype":"county",

--- a/data/109/201/061/9/1092010619.geojson
+++ b/data/109/201/061/9/1092010619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.371181,
-    "geom:area_square_m":4559225375.056971,
+    "geom:area_square_m":4559224686.348137,
     "geom:bbox":"9.705873,6.206773,10.453954,7.037671",
     "geom:latitude":6.606596,
     "geom:longitude":10.068433,
@@ -104,9 +104,10 @@
         "hasc:id":"CM.NW.MC",
         "wd:id":"Q685677"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896970,
-    "wof:geomhash":"faffde6294f1672b7329941b97809606",
+    "wof:geomhash":"696e2f581827267f8c2a1c2daa99ef43",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092010619,
-    "wof:lastmodified":1690867080,
+    "wof:lastmodified":1695886388,
     "wof:name":"Menchum",
     "wof:parent_id":85669941,
     "wof:placetype":"county",

--- a/data/109/201/064/9/1092010649.geojson
+++ b/data/109/201/064/9/1092010649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.147525,
-    "geom:area_square_m":1814230135.930157,
+    "geom:area_square_m":1814230073.521453,
     "geom:bbox":"9.590784,5.718167,10.084669,6.280126",
     "geom:latitude":5.982685,
     "geom:longitude":9.846329,
@@ -98,9 +98,10 @@
         "hasc:id":"CM.NW.MO",
         "wd:id":"Q2538015"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896971,
-    "wof:geomhash":"4defb4150fec2af5c07de622cd26d8dd",
+    "wof:geomhash":"27b7927247ab906c56211d3b975f3534",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092010649,
-    "wof:lastmodified":1690867074,
+    "wof:lastmodified":1695886383,
     "wof:name":"Momo",
     "wof:parent_id":85669941,
     "wof:placetype":"county",

--- a/data/109/201/066/1/1092010661.geojson
+++ b/data/109/201/066/1/1092010661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.150453,
-    "geom:area_square_m":1850257038.201248,
+    "geom:area_square_m":1850257160.502748,
     "geom:bbox":"9.908952,5.703311,10.388987,6.304806",
     "geom:latitude":5.977776,
     "geom:longitude":10.148618,
@@ -104,9 +104,10 @@
         "hasc:id":"CM.NW.ME",
         "wd:id":"Q966674"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896972,
-    "wof:geomhash":"0dbd84bd08b35fbf9510bd876f641793",
+    "wof:geomhash":"803bd16fc305cc1bb707d1607f97f9a3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092010661,
-    "wof:lastmodified":1690867081,
+    "wof:lastmodified":1695886388,
     "wof:name":"Mezam",
     "wof:parent_id":85669941,
     "wof:placetype":"county",

--- a/data/109/201/069/3/1092010693.geojson
+++ b/data/109/201/069/3/1092010693.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.08668,
-    "geom:area_square_m":1066050087.476738,
+    "geom:area_square_m":1066050595.920653,
     "geom:bbox":"10.254895,5.777061,10.6635,6.153153",
     "geom:latitude":5.947492,
     "geom:longitude":10.472279,
@@ -104,9 +104,10 @@
         "hasc:id":"CM.NW.NK",
         "wd:id":"Q2445374"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896973,
-    "wof:geomhash":"13b19e88227a6ca5c5a3ae483ae4ba23",
+    "wof:geomhash":"c89e762d9acfe6d72db872d79fc4203e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092010693,
-    "wof:lastmodified":1690867081,
+    "wof:lastmodified":1695886389,
     "wof:name":"Ngo Ketunjia",
     "wof:parent_id":85669941,
     "wof:placetype":"county",

--- a/data/109/201/072/7/1092010727.geojson
+++ b/data/109/201/072/7/1092010727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.35526,
-    "geom:area_square_m":4363501589.371894,
+    "geom:area_square_m":4363502026.869741,
     "geom:bbox":"10.410417,6.210402,11.209311,7.161492",
     "geom:latitude":6.624192,
     "geom:longitude":10.800043,
@@ -108,9 +108,10 @@
         "hasc:id":"CM.NW.DM",
         "wd:id":"Q2442736"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896974,
-    "wof:geomhash":"3c51a972b9fcba3fbce00323d40b0dee",
+    "wof:geomhash":"c733cafe7c1d066304e23a5dca8aa539",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1092010727,
-    "wof:lastmodified":1690867079,
+    "wof:lastmodified":1695886387,
     "wof:name":"Donga Mantung",
     "wof:parent_id":85669941,
     "wof:placetype":"county",

--- a/data/109/201/075/9/1092010759.geojson
+++ b/data/109/201/075/9/1092010759.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.134547,
-    "geom:area_square_m":1653446200.158775,
+    "geom:area_square_m":1653445848.014115,
     "geom:bbox":"10.071701,6.099604,10.568802,6.712791",
     "geom:latitude":6.362707,
     "geom:longitude":10.355281,
@@ -101,9 +101,10 @@
         "hasc:id":"CM.NW.BO",
         "wd:id":"Q2442750"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896975,
-    "wof:geomhash":"abfb1410f6f651c1c1a273fd96764b98",
+    "wof:geomhash":"73be247fbb1ed40e9b939ad884e410c8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092010759,
-    "wof:lastmodified":1690867078,
+    "wof:lastmodified":1695886387,
     "wof:name":"Boyo",
     "wof:parent_id":85669941,
     "wof:placetype":"county",

--- a/data/109/201/079/1/1092010791.geojson
+++ b/data/109/201/079/1/1092010791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.525006,
-    "geom:area_square_m":6468336337.929458,
+    "geom:area_square_m":6468337285.164086,
     "geom:bbox":"8.499454,4.255013,9.330534,5.430636",
     "geom:latitude":4.866199,
     "geom:longitude":8.938717,
@@ -104,9 +104,10 @@
         "hasc:id":"CM.SW.ND",
         "wd:id":"Q2445180"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896976,
-    "wof:geomhash":"83b6219b569f486e46e07bbf11202d25",
+    "wof:geomhash":"f6734ee3ea58d1eb2274d016cf069d3c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092010791,
-    "wof:lastmodified":1690867071,
+    "wof:lastmodified":1695886382,
     "wof:name":"Ndian",
     "wof:parent_id":85669967,
     "wof:placetype":"county",

--- a/data/109/201/082/3/1092010823.geojson
+++ b/data/109/201/082/3/1092010823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.166733,
-    "geom:area_square_m":2056227735.437706,
+    "geom:area_square_m":2056227735.437702,
     "geom:bbox":"8.93754612593,3.90676451088,9.55796086084,4.46043546494",
     "geom:latitude":4.167563,
     "geom:longitude":9.272435,
@@ -113,9 +113,10 @@
         "hasc:id":"CM.SW.FA",
         "wd:id":"Q955885"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896978,
-    "wof:geomhash":"53dcf9e410a824f6f1051d0fcd17da96",
+    "wof:geomhash":"9d9c190f0b71edca2cb922505ad6c31b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1092010823,
-    "wof:lastmodified":1566645947,
+    "wof:lastmodified":1695886383,
     "wof:name":"Fako",
     "wof:parent_id":85669967,
     "wof:placetype":"county",

--- a/data/109/201/085/9/1092010859.geojson
+++ b/data/109/201/085/9/1092010859.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.232692,
-    "geom:area_square_m":2867878380.311961,
+    "geom:area_square_m":2867878272.056365,
     "geom:bbox":"8.963706,4.214977,9.57047,5.106629",
     "geom:latitude":4.629044,
     "geom:longitude":9.31238,
@@ -98,9 +98,10 @@
         "hasc:id":"CM.SW.MM",
         "wd:id":"Q2582684"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896979,
-    "wof:geomhash":"83514aaff7b050a27ddabaaf8abdfaf4",
+    "wof:geomhash":"4c912029061e47cd9dfca9835eecc08a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092010859,
-    "wof:lastmodified":1690867072,
+    "wof:lastmodified":1695886383,
     "wof:name":"Meme",
     "wof:parent_id":85669967,
     "wof:placetype":"county",

--- a/data/109/201/088/9/1092010889.geojson
+++ b/data/109/201/088/9/1092010889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.109879,
-    "geom:area_square_m":1355942211.098006,
+    "geom:area_square_m":1355941950.072009,
     "geom:bbox":"11.189063,3.344633,11.530542,3.879874",
     "geom:latitude":3.633259,
     "geom:longitude":11.362978,
@@ -109,9 +109,10 @@
         "hasc:id":"CM.CE.MN",
         "wd:id":"Q2444484"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896980,
-    "wof:geomhash":"f9f52f331418301a363d2547f3dc54c5",
+    "wof:geomhash":"e29937fbb13adef2992e7df02e49430d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1092010889,
-    "wof:lastmodified":1690867079,
+    "wof:lastmodified":1695886387,
     "wof:name":"Mefou et Akono",
     "wof:parent_id":85669945,
     "wof:placetype":"county",

--- a/data/109/201/092/1/1092010921.geojson
+++ b/data/109/201/092/1/1092010921.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.268897,
-    "geom:area_square_m":3316937588.928592,
+    "geom:area_square_m":3316937284.91415,
     "geom:bbox":"11.500745,3.541111,12.165632,4.32715",
     "geom:latitude":3.976546,
     "geom:longitude":11.795321,
@@ -109,9 +109,10 @@
         "hasc:id":"CM.CE.MM",
         "wd:id":"Q2445054"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896981,
-    "wof:geomhash":"1c4c99b1c1f028daafef2a7182f637fb",
+    "wof:geomhash":"70d1152ea75551a4a031b66cd6231b26",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1092010921,
-    "wof:lastmodified":1690867081,
+    "wof:lastmodified":1695886388,
     "wof:name":"Mefou et Afamba",
     "wof:parent_id":85669945,
     "wof:placetype":"county",

--- a/data/109/201/094/3/1092010943.geojson
+++ b/data/109/201/094/3/1092010943.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.112898,
-    "geom:area_square_m":1389785117.855845,
+    "geom:area_square_m":1389785117.855863,
     "geom:bbox":"9.83266146078,5.17372316293,10.3387093735,5.63798884556",
     "geom:latitude":5.408111,
     "geom:longitude":10.075741,
@@ -98,9 +98,10 @@
         "hasc:id":"CM.OU.ME",
         "wd:id":"Q921417"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896982,
-    "wof:geomhash":"de969294db63bbf6152c0998bd2526a3",
+    "wof:geomhash":"3b3def0e2565c9815478fa5c2f5f08bb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092010943,
-    "wof:lastmodified":1566645958,
+    "wof:lastmodified":1695886389,
     "wof:name":"Menoua",
     "wof:parent_id":85669961,
     "wof:placetype":"county",

--- a/data/109/201/097/1/1092010971.geojson
+++ b/data/109/201/097/1/1092010971.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.078839,
-    "geom:area_square_m":970934793.637946,
+    "geom:area_square_m":970934706.226986,
     "geom:bbox":"9.991484,4.916393,10.377751,5.374312",
     "geom:latitude":5.143561,
     "geom:longitude":10.171277,
@@ -107,9 +107,10 @@
         "hasc:id":"CM.OU.HN",
         "wd:id":"Q2442640"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896983,
-    "wof:geomhash":"4728d8890e0f86513adeb168e63798a4",
+    "wof:geomhash":"76e90f64a7909dca52ebebfcbf1f9b63",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092010971,
-    "wof:lastmodified":1690867073,
+    "wof:lastmodified":1695886383,
     "wof:name":"Haut Nkam",
     "wof:parent_id":85669961,
     "wof:placetype":"county",

--- a/data/109/201/100/3/1092011003.geojson
+++ b/data/109/201/100/3/1092011003.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.775952,
-    "geom:area_square_m":9545192997.758801,
+    "geom:area_square_m":9545192823.003708,
     "geom:bbox":"8.831048,5.283022,9.91566,6.529991",
     "geom:latitude":5.820848,
     "geom:longitude":9.375688,
@@ -107,9 +107,10 @@
         "hasc:id":"CM.SW.MN",
         "wd:id":"Q636257"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896984,
-    "wof:geomhash":"56e2b412a3149f16ea48f61318697b80",
+    "wof:geomhash":"26030ab6051bbcc34cdef1fa1857906d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092011003,
-    "wof:lastmodified":1690867077,
+    "wof:lastmodified":1695886386,
     "wof:name":"Manyu",
     "wof:parent_id":85669967,
     "wof:placetype":"county",

--- a/data/109/201/103/5/1092011035.geojson
+++ b/data/109/201/103/5/1092011035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0521,
-    "geom:area_square_m":641196704.799596,
+    "geom:area_square_m":641196744.009223,
     "geom:bbox":"9.772277,5.371017,10.101244,5.751562",
     "geom:latitude":5.560055,
     "geom:longitude":9.923812,
@@ -104,9 +104,10 @@
         "hasc:id":"CM.SW.LE",
         "wd:id":"Q2443757"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896985,
-    "wof:geomhash":"27ad453fb6adac8b2f7fe2dec7f10768",
+    "wof:geomhash":"1940a8e5a2d57a07e335103b413ff38b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092011035,
-    "wof:lastmodified":1690867069,
+    "wof:lastmodified":1695886380,
     "wof:name":"Lebialem",
     "wof:parent_id":85669967,
     "wof:placetype":"county",

--- a/data/109/201/106/3/1092011063.geojson
+++ b/data/109/201/106/3/1092011063.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.280227,
-    "geom:area_square_m":3451266638.632983,
+    "geom:area_square_m":3451266638.632942,
     "geom:bbox":"9.18621380245,4.60466470737,9.9111978651,5.48941570132",
     "geom:latitude":5.110077,
     "geom:longitude":9.586202,
@@ -102,9 +102,10 @@
         "hasc:id":"CM.SW.KM",
         "wd:id":"Q2444337"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896986,
-    "wof:geomhash":"824a208e449b6730524e1e2ce60793a2",
+    "wof:geomhash":"cec3e6b0069090cc0a99fb2c10baeaed",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1092011063,
-    "wof:lastmodified":1566645953,
+    "wof:lastmodified":1695886386,
     "wof:name":"Koupe et Manengouba",
     "wof:parent_id":85669967,
     "wof:placetype":"county",

--- a/data/109/201/108/7/1092011087.geojson
+++ b/data/109/201/108/7/1092011087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.314626,
-    "geom:area_square_m":3877418413.905272,
+    "geom:area_square_m":3877418413.905194,
     "geom:bbox":"9.41374811204,4.06493311926,10.1135037941,5.33426601995",
     "geom:latitude":4.673335,
     "geom:longitude":9.76915,
@@ -95,9 +95,10 @@
         "hasc:id":"CM.LT.MU",
         "wd:id":"Q2445609"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896988,
-    "wof:geomhash":"865519b208f772c4cf2c274228b03356",
+    "wof:geomhash":"7424e4e4b0ce68dfd4b9e93d5a61a2bd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1092011087,
-    "wof:lastmodified":1566645954,
+    "wof:lastmodified":1695886387,
     "wof:name":"Moungo",
     "wof:parent_id":85669937,
     "wof:placetype":"county",

--- a/data/109/201/111/9/1092011119.geojson
+++ b/data/109/201/111/9/1092011119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.500652,
-    "geom:area_square_m":6171362089.920597,
+    "geom:area_square_m":6171361543.53905,
     "geom:bbox":"9.756509,4.066928,10.65274,5.107177",
     "geom:latitude":4.518505,
     "geom:longitude":10.149878,
@@ -98,9 +98,10 @@
         "hasc:id":"CM.LT.NK",
         "wd:id":"Q2445718"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896989,
-    "wof:geomhash":"51eb5d98599756b97a0c6d4572201c09",
+    "wof:geomhash":"2d17e4cd913a91055738d264012a9691",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092011119,
-    "wof:lastmodified":1690867074,
+    "wof:lastmodified":1695886384,
     "wof:name":"Nkam",
     "wof:parent_id":85669937,
     "wof:placetype":"county",

--- a/data/109/201/115/3/1092011153.geojson
+++ b/data/109/201/115/3/1092011153.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.753701,
-    "geom:area_square_m":9297574805.934402,
+    "geom:area_square_m":9297574805.934416,
     "geom:bbox":"9.5525101237,3.25997629385,11.0777473375,4.61201441561",
     "geom:latitude":3.934313,
     "geom:longitude":10.283808,
@@ -99,9 +99,10 @@
         "hasc:id":"CM.LT.SM",
         "wd:id":"Q2445164"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896990,
-    "wof:geomhash":"1f831700a3e6bfa60d859579a8d9dca3",
+    "wof:geomhash":"278986b013c26fcbc97919e215ca6c02",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1092011153,
-    "wof:lastmodified":1566645958,
+    "wof:lastmodified":1695886389,
     "wof:name":"Sanaga Maritime",
     "wof:parent_id":85669937,
     "wof:placetype":"county",

--- a/data/109/201/118/7/1092011187.geojson
+++ b/data/109/201/118/7/1092011187.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.516937,
-    "geom:area_square_m":6378605223.968667,
+    "geom:area_square_m":6378606269.75773,
     "geom:bbox":"10.23059,3.330131,11.257762,4.186986",
     "geom:latitude":3.707506,
     "geom:longitude":10.813747,
@@ -108,9 +108,10 @@
         "hasc:id":"CM.CE.NK",
         "wd:id":"Q729464"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896991,
-    "wof:geomhash":"2e4a827037166d503095babcdce50ff6",
+    "wof:geomhash":"8622f7e449a924eefde9169bc1cafbda",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1092011187,
-    "wof:lastmodified":1690867075,
+    "wof:lastmodified":1695886384,
     "wof:name":"Nyong et kelle",
     "wof:parent_id":85669945,
     "wof:placetype":"county",

--- a/data/109/201/120/9/1092011209.geojson
+++ b/data/109/201/120/9/1092011209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.292364,
-    "geom:area_square_m":3608713912.044746,
+    "geom:area_square_m":3608714516.19875,
     "geom:bbox":"11.060862,3.104148,12.011434,3.829077",
     "geom:latitude":3.411383,
     "geom:longitude":11.553924,
@@ -105,9 +105,10 @@
         "hasc:id":"CM.CE.NS",
         "wd:id":"Q2445625"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896992,
-    "wof:geomhash":"2ca528459cb411aa6532b3fbbb6f3405",
+    "wof:geomhash":"580c54eb987cb1e93d3842742c89c4c0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1092011209,
-    "wof:lastmodified":1690867075,
+    "wof:lastmodified":1695886384,
     "wof:name":"Nyong et Soo",
     "wof:parent_id":85669945,
     "wof:placetype":"county",

--- a/data/109/201/124/3/1092011243.geojson
+++ b/data/109/201/124/3/1092011243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.500823,
-    "geom:area_square_m":6178569423.384177,
+    "geom:area_square_m":6178570177.636411,
     "geom:bbox":"11.790235,3.290973,12.807897,4.390236",
     "geom:latitude":3.872872,
     "geom:longitude":12.339635,
@@ -105,9 +105,10 @@
         "hasc:id":"CM.CE.NM",
         "wd:id":"Q587099"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896993,
-    "wof:geomhash":"0b5e22edd29187944993635d55deca2d",
+    "wof:geomhash":"26ed3f65c2806fa919bbe51b97c4af8e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1092011243,
-    "wof:lastmodified":1690867082,
+    "wof:lastmodified":1695886390,
     "wof:name":"Nyong et Mfoumou",
     "wof:parent_id":85669945,
     "wof:placetype":"county",

--- a/data/109/201/127/7/1092011277.geojson
+++ b/data/109/201/127/7/1092011277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.955407,
-    "geom:area_square_m":11774166552.17141,
+    "geom:area_square_m":11774165756.347668,
     "geom:bbox":"11.707808,4.059084,13.246946,5.279174",
     "geom:latitude":4.686882,
     "geom:longitude":12.504576,
@@ -102,9 +102,10 @@
         "hasc:id":"CM.CE.HS",
         "wd:id":"Q2443161"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896994,
-    "wof:geomhash":"2338eb57627e0efe2600d38cd3b77217",
+    "wof:geomhash":"f421ce01cfb20e5e9eaf64d38d239060",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1092011277,
-    "wof:lastmodified":1690867075,
+    "wof:lastmodified":1695886385,
     "wof:name":"Haute Sanaga",
     "wof:parent_id":85669945,
     "wof:placetype":"county",

--- a/data/109/201/130/9/1092011309.geojson
+++ b/data/109/201/130/9/1092011309.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.553573,
-    "geom:area_square_m":6821670787.944362,
+    "geom:area_square_m":6821670815.258763,
     "geom:bbox":"10.337879,4.190724,11.381991,5.238247",
     "geom:latitude":4.730192,
     "geom:longitude":10.950087,
@@ -108,9 +108,10 @@
         "hasc:id":"CM.CE.MI",
         "wd:id":"Q2445034"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896995,
-    "wof:geomhash":"428b92537f8d2699f8795da28cf4d990",
+    "wof:geomhash":"131ba8e499e6481bc07eae9f8f2a817f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1092011309,
-    "wof:lastmodified":1690867078,
+    "wof:lastmodified":1695886387,
     "wof:name":"Mbam et Inoubou",
     "wof:parent_id":85669945,
     "wof:placetype":"county",

--- a/data/109/201/134/7/1092011347.geojson
+++ b/data/109/201/134/7/1092011347.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.935218,
-    "geom:area_square_m":36230959854.166916,
+    "geom:area_square_m":36230962704.212318,
     "geom:bbox":"12.493094,2.124977,14.59847,4.605948",
     "geom:latitude":3.339936,
     "geom:longitude":13.578485,
@@ -111,9 +111,10 @@
         "hasc:id":"CM.ES.HN",
         "wd:id":"Q2442655"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896996,
-    "wof:geomhash":"5ec37bc868827a4ab08da5085954b8ee",
+    "wof:geomhash":"ff2b47f81d8cc8297cbf9609315a2474",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1092011347,
-    "wof:lastmodified":1690867070,
+    "wof:lastmodified":1695886381,
     "wof:name":"Haut Nyong",
     "wof:parent_id":85669949,
     "wof:placetype":"county",

--- a/data/109/201/136/5/1092011365.geojson
+++ b/data/109/201/136/5/1092011365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.62079,
-    "geom:area_square_m":20017566612.847122,
+    "geom:area_square_m":20017563638.375603,
     "geom:bbox":"11.594504,2.170731,13.680087,3.681679",
     "geom:latitude":2.771568,
     "geom:longitude":12.611847,
@@ -111,9 +111,10 @@
         "hasc:id":"CM.SU.DL",
         "wd:id":"Q784802"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896997,
-    "wof:geomhash":"120552ecf78c9e0e082321153381cb0f",
+    "wof:geomhash":"31aa7c0860d1b910edf345b6c049ac8c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1092011365,
-    "wof:lastmodified":1690867076,
+    "wof:lastmodified":1695886385,
     "wof:name":"Dja et Lobo",
     "wof:parent_id":85669971,
     "wof:placetype":"county",

--- a/data/109/201/139/5/1092011395.geojson
+++ b/data/109/201/139/5/1092011395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.115433,
-    "geom:area_square_m":26044313196.540199,
+    "geom:area_square_m":26044311775.959469,
     "geom:bbox":"12.809184,4.336201,14.630499,6.061748",
     "geom:latitude":5.321227,
     "geom:longitude":13.750661,
@@ -108,9 +108,10 @@
         "hasc:id":"CM.ES.LD",
         "wd:id":"Q2443276"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473896998,
-    "wof:geomhash":"23494cc785aff87ac1c588b71d766e57",
+    "wof:geomhash":"1352c4936ad1a7a3a1ce86f22a996bad",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1092011395,
-    "wof:lastmodified":1690867078,
+    "wof:lastmodified":1695886387,
     "wof:name":"Lom et Djerem",
     "wof:parent_id":85669949,
     "wof:placetype":"county",

--- a/data/109/201/143/1/1092011431.geojson
+++ b/data/109/201/143/1/1092011431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.314836,
-    "geom:area_square_m":16212707113.298023,
+    "geom:area_square_m":16212707273.805143,
     "geom:bbox":"13.508191,3.666267,15.184759,5.283228",
     "geom:latitude":4.273442,
     "geom:longitude":14.384442,
@@ -101,9 +101,10 @@
         "hasc:id":"CM.ES.KA",
         "wd:id":"Q2444345"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897000,
-    "wof:geomhash":"8c80afc856f3e7a4b32757bd10facb70",
+    "wof:geomhash":"ca06a420b5eb0b0519ddc47c5009c18d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092011431,
-    "wof:lastmodified":1690867075,
+    "wof:lastmodified":1695886385,
     "wof:name":"Kadey",
     "wof:parent_id":85669949,
     "wof:placetype":"county",

--- a/data/109/201/146/5/1092011465.geojson
+++ b/data/109/201/146/5/1092011465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.504417,
-    "geom:area_square_m":30929532490.552792,
+    "geom:area_square_m":30929530979.435005,
     "geom:bbox":"14.325504,1.652085,16.191045,4.021286",
     "geom:latitude":2.794711,
     "geom:longitude":15.24462,
@@ -102,9 +102,10 @@
         "hasc:id":"CM.ES.BN",
         "wd:id":"Q2443133"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897001,
-    "wof:geomhash":"46f7b39df444029151074ed2adf6407f",
+    "wof:geomhash":"0255bde454ae7117832af0e3c6cdd421",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1092011465,
-    "wof:lastmodified":1690867082,
+    "wof:lastmodified":1695886390,
     "wof:name":"Boumba et Ngoko",
     "wof:parent_id":85669949,
     "wof:placetype":"county",

--- a/data/109/201/147/9/1092011479.geojson
+++ b/data/109/201/147/9/1092011479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.343419,
-    "geom:area_square_m":4182616510.501513,
+    "geom:area_square_m":4182616510.501467,
     "geom:bbox":"13.2744624437,9.5653134838,14.2298465507,10.2606088388",
     "geom:latitude":9.945078,
     "geom:longitude":13.822299,
@@ -101,9 +101,10 @@
         "hasc:id":"CM.NO.ML",
         "wd:id":"Q2443752"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897002,
-    "wof:geomhash":"de4f5c9f465b86f40d22db974744c269",
+    "wof:geomhash":"17abbe675e37512ce995c8059a651ac6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092011479,
-    "wof:lastmodified":1566645960,
+    "wof:lastmodified":1695886390,
     "wof:name":"Mayo Louti",
     "wof:parent_id":85669957,
     "wof:placetype":"county",

--- a/data/109/201/150/1/1092011501.geojson
+++ b/data/109/201/150/1/1092011501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.698063,
-    "geom:area_square_m":8574655540.385821,
+    "geom:area_square_m":8574654795.703033,
     "geom:bbox":"11.181339,5.971732,12.20827,7.257024",
     "geom:latitude":6.582586,
     "geom:longitude":11.736318,
@@ -107,9 +107,10 @@
         "hasc:id":"CM.AD.MB",
         "wd:id":"Q2443291"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897003,
-    "wof:geomhash":"fcb4577275d6200884569b321934e875",
+    "wof:geomhash":"cbab822ce07412776c61ac5c2b10425c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092011501,
-    "wof:lastmodified":1690867069,
+    "wof:lastmodified":1695886381,
     "wof:name":"Mayo Banyo",
     "wof:parent_id":85669953,
     "wof:placetype":"county",

--- a/data/109/201/154/5/1092011545.geojson
+++ b/data/109/201/154/5/1092011545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.855587,
-    "geom:area_square_m":10489875428.06411,
+    "geom:area_square_m":10489875498.782059,
     "geom:bbox":"11.811028,6.874421,13.247889,8.186707",
     "geom:latitude":7.458665,
     "geom:longitude":12.477744,
@@ -114,9 +114,10 @@
         "hasc:id":"CM.AD.FD",
         "wd:id":"Q2583647"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897004,
-    "wof:geomhash":"4a073a1d8a87d2812a4dae830b146b3f",
+    "wof:geomhash":"353f9dfaf8f136fd964de0dd8ccf0ff7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1092011545,
-    "wof:lastmodified":1690867076,
+    "wof:lastmodified":1695886385,
     "wof:name":"Faro et Deo",
     "wof:parent_id":85669953,
     "wof:placetype":"county",

--- a/data/109/201/158/1/1092011581.geojson
+++ b/data/109/201/158/1/1092011581.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.408976,
-    "geom:area_square_m":17285138581.300339,
+    "geom:area_square_m":17285138998.708607,
     "geom:bbox":"12.822205,6.514486,14.677308,7.973785",
     "geom:latitude":7.186495,
     "geom:longitude":13.660422,
@@ -122,9 +122,10 @@
         "hasc:id":"CM.AD.VI",
         "wd:id":"Q667019"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897006,
-    "wof:geomhash":"cecc085c81993905785d81b8fa6bd1ec",
+    "wof:geomhash":"00bd9ed9b078a0b11ff502da55263743",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1092011581,
-    "wof:lastmodified":1690867070,
+    "wof:lastmodified":1695886741,
     "wof:name":"Vina",
     "wof:parent_id":85669953,
     "wof:placetype":"county",

--- a/data/109/201/160/5/1092011605.geojson
+++ b/data/109/201/160/5/1092011605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.081584,
-    "geom:area_square_m":13288619757.654139,
+    "geom:area_square_m":13288620908.003042,
     "geom:bbox":"11.98936,5.999414,13.418968,7.058053",
     "geom:latitude":6.472522,
     "geom:longitude":12.71186,
@@ -113,9 +113,10 @@
         "hasc:id":"CM.AD.DJ",
         "wd:id":"Q1232309"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897007,
-    "wof:geomhash":"ebf2c52c065816612fcb0e24c4a67fbe",
+    "wof:geomhash":"ab354be6c422ac90c6947031d98a4bba",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1092011605,
-    "wof:lastmodified":1690867070,
+    "wof:lastmodified":1695886381,
     "wof:name":"Djerem",
     "wof:parent_id":85669953,
     "wof:placetype":"county",

--- a/data/109/201/163/3/1092011633.geojson
+++ b/data/109/201/163/3/1092011633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.189631,
-    "geom:area_square_m":14615793494.855946,
+    "geom:area_square_m":14615794415.616707,
     "geom:bbox":"13.280844,5.99925,15.2341,7.224003",
     "geom:latitude":6.482375,
     "geom:longitude":14.224526,
@@ -101,9 +101,10 @@
         "hasc:id":"CM.AD.MR",
         "wd:id":"Q937235"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897008,
-    "wof:geomhash":"c15af90a2cfc8ef46b273d6827443f54",
+    "wof:geomhash":"6724f15d70153da846a9fc8de4be48bb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092011633,
-    "wof:lastmodified":1690867077,
+    "wof:lastmodified":1695886386,
     "wof:name":"Mbere",
     "wof:parent_id":85669953,
     "wof:placetype":"county",

--- a/data/109/201/166/7/1092011667.geojson
+++ b/data/109/201/166/7/1092011667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.968081,
-    "geom:area_square_m":11846518170.476505,
+    "geom:area_square_m":11846518790.197191,
     "geom:bbox":"12.238752,7.593798,13.485288,9.251676",
     "geom:latitude":8.24789,
     "geom:longitude":12.875582,
@@ -98,9 +98,10 @@
         "hasc:id":"CM.NO.FA",
         "wd:id":"Q2443138"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897009,
-    "wof:geomhash":"76cc0ba23cf81d17ac6bb9ae59fafc3f",
+    "wof:geomhash":"600c38373bb0c9dfb13c1fb28a2ec2ef",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092011667,
-    "wof:lastmodified":1690867070,
+    "wof:lastmodified":1695886381,
     "wof:name":"Faro",
     "wof:parent_id":85669957,
     "wof:placetype":"county",

--- a/data/109/201/170/3/1092011703.geojson
+++ b/data/109/201/170/3/1092011703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.004534,
-    "geom:area_square_m":36777870664.740631,
+    "geom:area_square_m":36777870664.740753,
     "geom:bbox":"13.005942045,7.01518987569,15.5936466378,9.36770421373",
     "geom:latitude":8.118121,
     "geom:longitude":14.470442,
@@ -102,9 +102,10 @@
         "hasc:id":"CM.NO.MA",
         "wd:id":"Q2443767"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897010,
-    "wof:geomhash":"384c7ffd2e22767307473a495563a2d5",
+    "wof:geomhash":"d25894464ee9ddbb235470effc6336fb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1092011703,
-    "wof:lastmodified":1566645959,
+    "wof:lastmodified":1695886390,
     "wof:name":"Mayo Rey",
     "wof:parent_id":85669957,
     "wof:placetype":"county",

--- a/data/109/201/173/5/1092011735.geojson
+++ b/data/109/201/173/5/1092011735.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.007968,
-    "geom:area_square_m":12189177048.393953,
+    "geom:area_square_m":12189176346.758289,
     "geom:bbox":"14.085492,10.994712,15.146823,13.076586",
     "geom:latitude":12.033755,
     "geom:longitude":14.669049,
@@ -108,9 +108,10 @@
         "hasc:id":"CM.EN.LC",
         "wd:id":"Q576311"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897012,
-    "wof:geomhash":"f84245493ebd26d8d2a1d72fa4317581",
+    "wof:geomhash":"de0b63aa2fad3d96f8c2b49d9df13839",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1092011735,
-    "wof:lastmodified":1690867074,
+    "wof:lastmodified":1695886384,
     "wof:name":"Logone et Chari",
     "wof:parent_id":85669933,
     "wof:placetype":"county",

--- a/data/109/201/175/9/1092011759.geojson
+++ b/data/109/201/175/9/1092011759.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.217648,
-    "geom:area_square_m":2640853429.413336,
+    "geom:area_square_m":2640853429.413471,
     "geom:bbox":"13.8782815828,10.7831148132,14.5014004005,11.4235452937",
     "geom:latitude":11.10593,
     "geom:longitude":14.202807,
@@ -101,9 +101,10 @@
         "hasc:id":"CM.EN.MS",
         "wd:id":"Q613340"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897013,
-    "wof:geomhash":"7e56d1c8bec5d3fcc6984efe19e9ae86",
+    "wof:geomhash":"60b12f4279477d1995eed00fd5043f80",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092011759,
-    "wof:lastmodified":1566645951,
+    "wof:lastmodified":1695886386,
     "wof:name":"Mayo Sava",
     "wof:parent_id":85669933,
     "wof:placetype":"county",

--- a/data/109/201/189/9/1092011899.geojson
+++ b/data/109/201/189/9/1092011899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.370575,
-    "geom:area_square_m":4504359684.460103,
+    "geom:area_square_m":4504359413.991773,
     "geom:bbox":"13.402901,10.081621,14.094118,11.143124",
     "geom:latitude":10.575497,
     "geom:longitude":13.784721,
@@ -104,9 +104,10 @@
         "hasc:id":"CM.EN.MT",
         "wd:id":"Q2443777"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897014,
-    "wof:geomhash":"c339ee18db77b47905ac5f0b5dbc1709",
+    "wof:geomhash":"bbeea296b7b8f5d6966ed20af97035c0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092011899,
-    "wof:lastmodified":1690867074,
+    "wof:lastmodified":1695886384,
     "wof:name":"Mayo Tsanaga",
     "wof:parent_id":85669933,
     "wof:placetype":"county",

--- a/data/109/201/196/3/1092011963.geojson
+++ b/data/109/201/196/3/1092011963.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.410559,
-    "geom:area_square_m":4995467185.325834,
+    "geom:area_square_m":4995466225.39145,
     "geom:bbox":"14.047076,9.935189,14.985925,10.65646",
     "geom:latitude":10.258781,
     "geom:longitude":14.537147,
@@ -101,9 +101,10 @@
         "hasc:id":"CM.EN.KA",
         "wd:id":"Q2444363"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897021,
-    "wof:geomhash":"2bfdad94de91fadc0611562a2d2d3531",
+    "wof:geomhash":"3d31923ee008f65b2fc8ef650c8ba0d6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092011963,
-    "wof:lastmodified":1690867076,
+    "wof:lastmodified":1695886386,
     "wof:name":"Mayo Kani",
     "wof:parent_id":85669933,
     "wof:placetype":"county",

--- a/data/109/201/197/7/1092011977.geojson
+++ b/data/109/201/197/7/1092011977.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.395033,
-    "geom:area_square_m":4799475116.746019,
+    "geom:area_square_m":4799474378.277686,
     "geom:bbox":"13.952924,10.170321,14.810668,11.154746",
     "geom:latitude":10.714415,
     "geom:longitude":14.417199,
@@ -101,9 +101,10 @@
         "hasc:id":"CM.EN.DI",
         "wd:id":"Q2583656"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897022,
-    "wof:geomhash":"839c69b6e50a08f26db1ea64fbca0414",
+    "wof:geomhash":"f52de36cedb51c109729eab422b4efd7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092011977,
-    "wof:lastmodified":1690867077,
+    "wof:lastmodified":1695886387,
     "wof:name":"Diamare",
     "wof:parent_id":85669933,
     "wof:placetype":"county",

--- a/data/109/201/200/9/1092012009.geojson
+++ b/data/109/201/200/9/1092012009.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.180846,
-    "geom:area_square_m":2223096947.57688,
+    "geom:area_square_m":2223097447.541528,
     "geom:bbox":"10.427633,5.975764,11.052499,6.478767",
     "geom:latitude":6.202552,
     "geom:longitude":10.722395,
@@ -119,9 +119,10 @@
         "hasc:id":"CM.NW.BU",
         "wd:id":"Q702284"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897023,
-    "wof:geomhash":"bd20d318102619f25178b8295d512d42",
+    "wof:geomhash":"32103f3450eb797487aadbf5865b0209",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1092012009,
-    "wof:lastmodified":1690867080,
+    "wof:lastmodified":1695886389,
     "wof:name":"Bui",
     "wof:parent_id":85669941,
     "wof:placetype":"county",

--- a/data/109/201/204/5/1092012045.geojson
+++ b/data/109/201/204/5/1092012045.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025775,
-    "geom:area_square_m":317988009.384067,
+    "geom:area_square_m":317987953.827268,
     "geom:bbox":"11.413966,3.723659,11.576568,4.023592",
     "geom:latitude":3.875654,
     "geom:longitude":11.509417,
@@ -107,9 +107,10 @@
         "hasc:id":"CM.CE.MF",
         "wd:id":"Q2445046"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897024,
-    "wof:geomhash":"a5536abeb33525108e40f26346b4fb86",
+    "wof:geomhash":"c56bd8c032090cd7e3051ecaf1328b95",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092012045,
-    "wof:lastmodified":1690867073,
+    "wof:lastmodified":1695886383,
     "wof:name":"Mfoundi",
     "wof:parent_id":85669945,
     "wof:placetype":"county",

--- a/data/109/201/207/9/1092012079.geojson
+++ b/data/109/201/207/9/1092012079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.244804,
-    "geom:area_square_m":3019030793.168519,
+    "geom:area_square_m":3019031056.591348,
     "geom:bbox":"11.073381,3.794956,11.732615,4.499076",
     "geom:latitude":4.167717,
     "geom:longitude":11.385911,
@@ -104,9 +104,10 @@
         "hasc:id":"CM.CE.LE",
         "wd:id":"Q607493"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897025,
-    "wof:geomhash":"b39b42f2062dc333b09e219cf66aafe5",
+    "wof:geomhash":"ce9ec901aa6b7e369102a5c501bd2fc5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092012079,
-    "wof:lastmodified":1690867080,
+    "wof:lastmodified":1695886389,
     "wof:name":"Lekie",
     "wof:parent_id":85669945,
     "wof:placetype":"county",

--- a/data/109/201/210/7/1092012107.geojson
+++ b/data/109/201/210/7/1092012107.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.587471,
-    "geom:area_square_m":7257667888.856167,
+    "geom:area_square_m":7257667888.856154,
     "geom:bbox":"10.1884650695,2.17104264059,11.6804360432,2.79164553539",
     "geom:latitude":2.423729,
     "geom:longitude":10.92015,
@@ -105,9 +105,10 @@
         "hasc:id":"CM.SU.VN",
         "wd:id":"Q2445579"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897026,
-    "wof:geomhash":"99a5d636d2ff62084be231bf5210de4d",
+    "wof:geomhash":"619367e4ce186481548f4998cb11cf31",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1092012107,
-    "wof:lastmodified":1566645945,
+    "wof:lastmodified":1695886382,
     "wof:name":"Vallee du Ntem",
     "wof:parent_id":85669971,
     "wof:placetype":"county",

--- a/data/109/201/213/9/1092012139.geojson
+++ b/data/109/201/213/9/1092012139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.929585,
-    "geom:area_square_m":11479545807.728666,
+    "geom:area_square_m":11479545807.728743,
     "geom:bbox":"9.81507876532,2.14137938059,11.1790007471,3.59488595032",
     "geom:latitude":2.902049,
     "geom:longitude":10.311158,
@@ -92,9 +92,10 @@
         "hasc:id":"CM.SU.OC",
         "wd:id":"Q2445229"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897028,
-    "wof:geomhash":"7c63c63f77e1d2fa01efc11b65f7660c",
+    "wof:geomhash":"9bc9f8eff13007f5b8dc5f157808049f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1092012139,
-    "wof:lastmodified":1566645956,
+    "wof:lastmodified":1695886388,
     "wof:name":"Ocean",
     "wof:parent_id":85669971,
     "wof:placetype":"county",

--- a/data/109/201/217/3/1092012173.geojson
+++ b/data/109/201/217/3/1092012173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.706615,
-    "geom:area_square_m":8726959424.150537,
+    "geom:area_square_m":8726958171.206264,
     "geom:bbox":"10.575406,2.267235,12.260661,3.213276",
     "geom:latitude":2.796258,
     "geom:longitude":11.394946,
@@ -107,9 +107,10 @@
         "hasc:id":"CM.SU.MV",
         "wd:id":"Q2445743"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897029,
-    "wof:geomhash":"93f7462ddf5c0e1175df011ca2b15482",
+    "wof:geomhash":"55302ef6e550e71977d1848d6688f28e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092012173,
-    "wof:lastmodified":1690867071,
+    "wof:lastmodified":1695886382,
     "wof:name":"Mvila",
     "wof:parent_id":85669971,
     "wof:placetype":"county",

--- a/data/109/201/219/7/1092012197.geojson
+++ b/data/109/201/219/7/1092012197.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035231,
-    "geom:area_square_m":433784424.172344,
+    "geom:area_square_m":433784459.10587,
     "geom:bbox":"10.242617,5.142435,10.445668,5.459737",
     "geom:latitude":5.293987,
     "geom:longitude":10.343171,
@@ -107,9 +107,10 @@
         "hasc:id":"CM.OU.HP",
         "wd:id":"Q2443778"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897030,
-    "wof:geomhash":"4876233750a0d72a98a9d6770dd4a826",
+    "wof:geomhash":"1f17a44b1a9d683b63b8573d0646b7f0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092012197,
-    "wof:lastmodified":1690867071,
+    "wof:lastmodified":1695886382,
     "wof:name":"Hauts Plateaux",
     "wof:parent_id":85669961,
     "wof:placetype":"county",

--- a/data/109/201/222/5/1092012225.geojson
+++ b/data/109/201/222/5/1092012225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029358,
-    "geom:area_square_m":361443032.562423,
+    "geom:area_square_m":361443032.562441,
     "geom:bbox":"10.3626635493,5.20358954786,10.5901441892,5.45341373292",
     "geom:latitude":5.340637,
     "geom:longitude":10.471364,
@@ -101,9 +101,10 @@
         "hasc:id":"CM.OU.KK",
         "wd:id":"Q2443749"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897032,
-    "wof:geomhash":"53dbac1b78ed327e543a168f19741044",
+    "wof:geomhash":"ba72d0796550ec8113037215ac0c5644",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1092012225,
-    "wof:lastmodified":1566645956,
+    "wof:lastmodified":1695886388,
     "wof:name":"Koung Khi",
     "wof:parent_id":85669961,
     "wof:placetype":"county",

--- a/data/109/201/225/7/1092012257.geojson
+++ b/data/109/201/225/7/1092012257.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070374,
-    "geom:area_square_m":868025974.276882,
+    "geom:area_square_m":868025920.474078,
     "geom:bbox":"9.335801,3.882572,9.864228,4.225323",
     "geom:latitude":4.03739,
     "geom:longitude":9.666242,
@@ -104,9 +104,10 @@
         "hasc:id":"CM.LT.WO",
         "wd:id":"Q769841"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897033,
-    "wof:geomhash":"84aa7ff441fa69518e8c5df3767abe51",
+    "wof:geomhash":"4c9f2d912ef427d1240d200662047604",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092012257,
-    "wof:lastmodified":1690867079,
+    "wof:lastmodified":1695886388,
     "wof:name":"Wouri",
     "wof:parent_id":85669937,
     "wof:placetype":"county",

--- a/data/109/201/228/7/1092012287.geojson
+++ b/data/109/201/228/7/1092012287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.133238,
-    "geom:area_square_m":13831336408.714678,
+    "geom:area_square_m":13831335066.220739,
     "geom:bbox":"12.843784,8.353165,14.291472,10.050394",
     "geom:latitude":9.222253,
     "geom:longitude":13.473848,
@@ -104,9 +104,10 @@
         "hasc:id":"CM.NO.BE",
         "wd:id":"Q2442627"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897034,
-    "wof:geomhash":"11ad7f81da5d9be376c4f052208c8b82",
+    "wof:geomhash":"55060d671cc5081613d95ab18656cabb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1092012287,
-    "wof:lastmodified":1690867072,
+    "wof:lastmodified":1695886383,
     "wof:name":"Benoue",
     "wof:parent_id":85669957,
     "wof:placetype":"county",

--- a/data/109/201/231/1/1092012311.geojson
+++ b/data/109/201/231/1/1092012311.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.138727,
-    "geom:area_square_m":26326514746.266468,
+    "geom:area_square_m":26326514023.457199,
     "geom:bbox":"11.066491,4.346158,13.076844,6.260577",
     "geom:latitude":5.426964,
     "geom:longitude":11.980835,
@@ -108,9 +108,10 @@
         "hasc:id":"CM.CE.MK",
         "wd:id":"Q2445194"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1473897036,
-    "wof:geomhash":"a8885f2381db9ba507de80a5400fee21",
+    "wof:geomhash":"dbc03a0d7deb5994f1e5c0f193f4d2e6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1092012311,
-    "wof:lastmodified":1690867080,
+    "wof:lastmodified":1695886389,
     "wof:name":"Mbam et Kim",
     "wof:parent_id":85669945,
     "wof:placetype":"county",

--- a/data/110/839/024/9/1108390249.geojson
+++ b/data/110/839/024/9/1108390249.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.435833,
-    "geom:area_square_m":5300581592.990283,
+    "geom:area_square_m":5300581592.990503,
     "geom:bbox":"14.7896295875,9.93445053339,15.689525703,11.0849784472",
     "geom:latitude":10.39759,
     "geom:longitude":15.098642,
@@ -130,9 +130,10 @@
         "qs_pg:id":264096,
         "wd:id":"Q2444290"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CM",
     "wof:created":1459008888,
-    "wof:geomhash":"0b947677a2e621ead00620e09d26c4cb",
+    "wof:geomhash":"f426c07a4bfe576026df4a50819534b0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1108390249,
-    "wof:lastmodified":1566645782,
+    "wof:lastmodified":1695886367,
     "wof:name":"Mayo Danay",
     "wof:parent_id":85669933,
     "wof:placetype":"county",

--- a/data/856/322/45/85632245.geojson
+++ b/data/856/322/45/85632245.geojson
@@ -1213,6 +1213,7 @@
         "hasc:id":"CM",
         "icao:code":"TJ",
         "ioc:id":"CMR",
+        "iso:code":"CM",
         "itu:id":"CME",
         "m49:code":"120",
         "marc:id":"cm",
@@ -1226,6 +1227,7 @@
         "wk:page":"Cameroon",
         "wmo:id":"CM"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CM",
     "wof:country_alpha3":"CMR",
     "wof:geom_alt":[
@@ -1250,7 +1252,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1694639523,
+    "wof:lastmodified":1695881178,
     "wof:name":"Cameroon",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/699/33/85669933.geojson
+++ b/data/856/699/33/85669933.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.837616,
-    "geom:area_square_m":34429914208.18557,
+    "geom:area_square_m":34429913150.528755,
     "geom:bbox":"13.402901,9.934451,15.689526,13.076586",
     "geom:latitude":11.080369,
     "geom:longitude":14.529637,
@@ -309,16 +309,18 @@
         "gn:id":2231755,
         "gp:id":2345040,
         "hasc:id":"CM.EN",
+        "iso:code":"CM-EN",
         "iso:id":"CM-EN",
         "qs_pg:id":1168634,
         "wd:id":"Q823976",
         "wk:page":"Far North Region (Cameroon)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"05bc63ea9951a812ac2c714b99ed1567",
+    "wof:geomhash":"15e31f75888cb8ce869db78e434febf8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -335,7 +337,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690867062,
+    "wof:lastmodified":1695884358,
     "wof:name":"Extreme Nord",
     "wof:parent_id":85632245,
     "wof:placetype":"region",

--- a/data/856/699/37/85669937.geojson
+++ b/data/856/699/37/85669937.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.639353,
-    "geom:area_square_m":20214381284.037121,
+    "geom:area_square_m":20214380414.812679,
     "geom:bbox":"9.335801,3.259976,11.077747,5.334266",
     "geom:latitude":4.258982,
     "geom:longitude":10.117622,
@@ -307,17 +307,19 @@
         "gn:id":2229336,
         "gp:id":2345034,
         "hasc:id":"CM.LT",
+        "iso:code":"CM-LT",
         "iso:id":"CM-LT",
         "qs_pg:id":318365,
         "unlc:id":"CM-LT",
         "wd:id":"Q845172",
         "wk:page":"Littoral Region (Cameroon)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"81aa95078759158242aa00a9b24f950d",
+    "wof:geomhash":"f4deb2046c2dc11d0be75875e4fc50dc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -334,7 +336,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690867064,
+    "wof:lastmodified":1695885134,
     "wof:name":"Littoral",
     "wof:parent_id":85632245,
     "wof:placetype":"region",

--- a/data/856/699/41/85669941.geojson
+++ b/data/856/699/41/85669941.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.426491,
-    "geom:area_square_m":17529809017.841122,
+    "geom:area_square_m":17529809564.91922,
     "geom:bbox":"9.590784,5.703311,11.209311,7.161492",
     "geom:latitude":6.365855,
     "geom:longitude":10.370626,
@@ -305,16 +305,18 @@
         "gn:id":2223602,
         "gp:id":2345035,
         "hasc:id":"CM.NW",
+        "iso:code":"CM-NW",
         "iso:id":"CM-NW",
         "qs_pg:id":279869,
         "wd:id":"Q823946",
         "wk:page":"Northwest Region (Cameroon)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f9d92f4e59fc22466ffbc2fdbe3eb906",
+    "wof:geomhash":"6a3573515a6b818aac1b9b6c51fc35ab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -331,7 +333,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690867064,
+    "wof:lastmodified":1695884358,
     "wof:name":"Nord Ouest",
     "wof:parent_id":85632245,
     "wof:placetype":"region",

--- a/data/856/699/45/85669945.geojson
+++ b/data/856/699/45/85669945.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.607184,
-    "geom:area_square_m":69098139246.600052,
+    "geom:area_square_m":69098139803.425446,
     "geom:bbox":"10.23059,3.104148,13.246946,6.260577",
     "geom:latitude":4.662836,
     "geom:longitude":11.821361,
@@ -311,17 +311,19 @@
         "gn:id":2233376,
         "gp:id":2345039,
         "hasc:id":"CM.CE",
+        "iso:code":"CM-CE",
         "iso:id":"CM-CE",
         "qs_pg:id":219528,
         "unlc:id":"CM-CE",
         "wd:id":"Q739951",
         "wk:page":"Centre Region (Cameroon)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a181566fcef9f8ad5d9e8f51397a7c82",
+    "wof:geomhash":"6741487c3f8a6bd481168d87cce5af58",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -338,7 +340,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690867063,
+    "wof:lastmodified":1695885133,
     "wof:name":"Centre",
     "wof:parent_id":85632245,
     "wof:placetype":"region",

--- a/data/856/699/49/85669949.geojson
+++ b/data/856/699/49/85669949.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":8.8699,
-    "geom:area_square_m":109417472042.55423,
+    "geom:area_square_m":109417472248.642639,
     "geom:bbox":"12.493094,1.652085,16.191045,6.061748",
     "geom:latitude":3.7969,
     "geom:longitude":14.209453,
@@ -307,16 +307,18 @@
         "gn:id":2231835,
         "gp:id":2345033,
         "hasc:id":"CM.ES",
+        "iso:code":"CM-ES",
         "iso:id":"CM-ES",
         "qs_pg:id":946776,
         "wd:id":"Q845168",
         "wk:page":"East Region (Cameroon)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c9c18ebfe2792458eeabfb5208847799",
+    "wof:geomhash":"f99c2343ce14ec5ebfd0ab3c93493fbd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -333,7 +335,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690867065,
+    "wof:lastmodified":1695884856,
     "wof:name":"Est",
     "wof:parent_id":85632245,
     "wof:placetype":"region",

--- a/data/856/699/53/85669953.geojson
+++ b/data/856/699/53/85669953.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.233837,
-    "geom:area_square_m":64254033677.994415,
+    "geom:area_square_m":64254035533.226494,
     "geom:bbox":"11.181339,5.971732,15.2341,8.186707",
     "geom:latitude":6.842853,
     "geom:longitude":13.142657,
@@ -315,17 +315,19 @@
         "gn:id":2236015,
         "gp:id":2345038,
         "hasc:id":"CM.AD",
+        "iso:code":"CM-AD",
         "iso:id":"CM-AD",
         "qs_pg:id":219527,
         "unlc:id":"CM-AD",
         "wd:id":"Q351514",
         "wk:page":"Adamawa Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e57173639f47fa7f697833f1ae2cb787",
+    "wof:geomhash":"2bee3c2fce005e73986d88bc41fe8ec4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -342,7 +344,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690867063,
+    "wof:lastmodified":1695885132,
     "wof:name":"Adamaoua",
     "wof:parent_id":85632245,
     "wof:placetype":"region",

--- a/data/856/699/57/85669957.geojson
+++ b/data/856/699/57/85669957.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.449272,
-    "geom:area_square_m":66638341754.435051,
+    "geom:area_square_m":66638341778.320526,
     "geom:bbox":"12.238752,7.01519,15.593647,10.260609",
     "geom:latitude":8.485929,
     "geom:longitude":13.93901,
@@ -305,16 +305,18 @@
         "gn:id":2223603,
         "gp:id":2345041,
         "hasc:id":"CM.NO",
+        "iso:code":"CM-NO",
         "iso:id":"CM-NO",
         "qs_pg:id":1168635,
         "wd:id":"Q502341",
         "wk:page":"North Region (Cameroon)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"630bb11b2d475a0261ee055bc46d9fa1",
+    "wof:geomhash":"c1969724a3037da312ddbd665445bb9b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -331,7 +333,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690867062,
+    "wof:lastmodified":1695885132,
     "wof:name":"Nord",
     "wof:parent_id":85632245,
     "wof:placetype":"region",

--- a/data/856/699/61/85669961.geojson
+++ b/data/856/699/61/85669961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.133606,
-    "geom:area_square_m":13952476564.137987,
+    "geom:area_square_m":13952476082.383215,
     "geom:bbox":"9.832661,4.880723,11.316864,6.263974",
     "geom:latitude":5.501867,
     "geom:longitude":10.651725,
@@ -307,16 +307,18 @@
         "gn:id":2222934,
         "gp:id":2345036,
         "hasc:id":"CM.OU",
+        "iso:code":"CM-OU",
         "iso:id":"CM-OU",
         "qs_pg:id":423626,
         "wd:id":"Q165784",
         "wk:page":"West Region (Cameroon)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"41be7fb8bafb28c864dc342ca9a06622",
+    "wof:geomhash":"ace1e6cc2f7ef405d46aaa89a8ba6d84",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -333,7 +335,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690867061,
+    "wof:lastmodified":1695884856,
     "wof:name":"Ouest",
     "wof:parent_id":85632245,
     "wof:placetype":"region",

--- a/data/856/699/67/85669967.geojson
+++ b/data/856/699/67/85669967.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.03271,
-    "geom:area_square_m":25030098836.233833,
+    "geom:area_square_m":25030099587.709446,
     "geom:bbox":"8.499454,3.906765,10.101244,6.529991",
     "geom:latitude":5.197571,
     "geom:longitude":9.290181,
@@ -305,16 +305,18 @@
         "gn:id":2221788,
         "gp:id":2345037,
         "hasc:id":"CM.SW",
+        "iso:code":"CM-SW",
         "iso:id":"CM-SW",
         "qs_pg:id":219526,
         "wd:id":"Q607499",
         "wk:page":"Southwest Region (Cameroon)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b16c77928d8cebe812959212f42f3a04",
+    "wof:geomhash":"ef3bb28260d3af479d957be09aa4004c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -331,7 +333,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690867062,
+    "wof:lastmodified":1695884358,
     "wof:name":"Sud Ouest",
     "wof:parent_id":85632245,
     "wof:placetype":"region",

--- a/data/856/699/71/85669971.geojson
+++ b/data/856/699/71/85669971.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.844461,
-    "geom:area_square_m":47481739664.384232,
+    "geom:area_square_m":47481734165.498741,
     "geom:bbox":"9.815079,2.141379,13.680087,3.681679",
     "geom:latitude":2.754503,
     "geom:longitude":11.573369,
@@ -310,16 +310,18 @@
         "gn:id":2221789,
         "gp:id":2345042,
         "hasc:id":"CM.SU",
+        "iso:code":"CM-SU",
         "iso:id":"CM-SU",
         "qs_pg:id":219529,
         "wd:id":"Q857122",
         "wk:page":"South Region (Cameroon)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"668d3982c17238016e838fffcb9b1850",
+    "wof:geomhash":"8fa4109e47fb33a76f488e10f924236c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -336,7 +338,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690867064,
+    "wof:lastmodified":1695884856,
     "wof:name":"Sud",
     "wof:parent_id":85632245,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.